### PR TITLE
update to 3.1.0-9332

### DIFF
--- a/com.qq.QQ.metainfo.xml
+++ b/com.qq.QQ.metainfo.xml
@@ -29,6 +29,7 @@
     <category>Network</category>
   </categories>
   <releases>
+    <release version="3.1.0-9332" date="2022-02-20"/>
     <release version="3.0.0-571" date="2022-12-30"/>
     <release version="2.0.1" date="2022-12-08"/>
   </releases>

--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -91,9 +91,9 @@ modules:
       - type: extra-data
         filename: qq.deb
         only-arches: [x86_64]
-        url: https://dldir1.qq.com/qqfile/qq/QQNT/c005c911/linuxqq_3.0.0-571_amd64.deb
-        sha256: f0a714859c20785cc6cab4084d69c953310f1993828f42c81cb991b8aaa48264
-        size: 108797658
+        url: https://dldir1.qq.com/qqfile/qq/QQNT/c6032ac7/linuxqq_3.1.0-9332_amd64.deb
+        sha256: 648743868884f18e146800db7da17527a54494432398e40f3f52565fb3bb7942
+        size: 125611548
         x-checker-data:
           type: html
           url: https://im.qq.com/rainbow/linuxQQDownload
@@ -103,9 +103,9 @@ modules:
       - type: extra-data
         filename: qq.deb
         only-arches: [aarch64]
-        url: https://dldir1.qq.com/qqfile/qq/QQNT/c005c911/linuxqq_3.0.0-571_arm64.deb
-        sha256: 2ef13e3ebcaae0a2eef8115856b1a24f005d80eac182e3c741def730c1657e26
-        size: 111054936
+        url: https://dldir1.qq.com/qqfile/qq/QQNT/c6032ac7/linuxqq_3.1.0-9332_arm64.deb
+        sha256: 09528fd63169e1151c4010ca4e8036d0682a107a87338e4e3b69a741a2b4bc15
+        size: 128616808
         x-checker-data:
           type: html
           url: https://im.qq.com/rainbow/linuxQQDownload


### PR DESCRIPTION
似乎这个新版本的 deb 包链接并没公开提供，是从 [AUR 包上](https://aur.archlinux.org/packages/linuxqq) 搜刮下来的，按 Arch Linux CN 那边的人说，他们是 [通过抓包更新信息来获取的](https://t.me/archlinuxcn_group/2687241)