### PR TITLE
修复在GNOME Wayland下的截图问题

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -1,7 +1,7 @@
 app-id: com.qq.QQ
-runtime: org.freedesktop.Platform
-runtime-version: '22.08'
-sdk: org.freedesktop.Sdk
+runtime: org.gnome.Platform
+runtime-version: '43'
+sdk: org.gnome.Sdk
 base: org.electronjs.Electron2.BaseApp
 base-version: '22.08'
 command: qq
@@ -14,10 +14,12 @@ finish-args:
   - --socket=pulseaudio
   - --device=all
   - --filesystem=xdg-download
+  - --talk-name=org.gnome.Shell.Screencast
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.login1
   - --filesystem=xdg-run/pipewire-0
+  - --filesystem=/tmp
 
 cleanup:
   - /include


### PR DESCRIPTION
因为qq使用gjs调用dbus:org.gnome.Shell.Screencast，而gjs包含在org.gnome.Platform这个runtime中，故而使用这个runtime。
调用这个dbus会先将数据写入/tmp，故而使用--filesystem=/tmp。我测试过了，没加这个截图是空的。