### PR TITLE
Add custom fontconfig.

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -93,7 +93,7 @@ modules:
       - type: extra-data
         filename: qq.deb
         only-arches: [x86_64]
-        url: http://dldir1.qq.com/qqfile/qq/QQNT/d3b9a722/linuxqq_3.2.0-16736_amd64.deb
+        url: https://dldir1.qq.com/qqfile/qq/QQNT/d3b9a722/linuxqq_3.2.0-16736_amd64.deb
         sha256: f7a87ae3c6ca3a34f3e9b9c6b4034c1d72cf13d6e1bcc5d99ce78d68c1111d5d
         size: 127951906
         # x-checker-data:
@@ -112,3 +112,16 @@ modules:
         #   type: html
         #   url: https://im.qq.com/rainbow/linuxQQDownload
         #   pattern: (https://[^"]+/linuxqq_([\d\.\-]+)_arm64.deb)
+  - name: fontconfig
+    buildsystem: simple
+    build-commands:
+      - install -pDm644 "local.conf" -t "/app/etc/fonts/";
+      - install -pDm644 "70-noto-cjk.conf" -t "/app/etc/fonts/conf.d/";
+      # `||:` return a successful exit status
+      - fc-cache -fsv ||:;
+    sources:
+      - type: file
+        url: https://gitlab.archlinux.org/archlinux/packaging/packages/noto-fonts-cjk/-/raw/5fd3534bf7a6e26c7506dc8f40dcd89f37d35627/70-noto-cjk.conf
+        sha256: 2417ac0e6720fe8da55ee59f16e36cfe96737bc21432460a322bb0f395e3a521
+      - type: file
+        path: local.conf

--- a/local.conf
+++ b/local.conf
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!-- /app/etc/fonts/local.conf file to configure application font access -->
+<fontconfig>
+
+	<!-- Load local application customization file -->
+	<include ignore_missing="yes">/app/etc/fonts/conf.d/</include>
+
+</fontconfig>


### PR DESCRIPTION
概述：

flatpak 在 `/etc/fonts/conf.d/50-flatpak.conf` 通过 `<include ignore_missing="yes">/app/etc/fonts/local.conf</include>` 加载 `/app/etc/fonts/local.conf`，因此需要添加这一文件。

此 PR 新增的文件 `local.conf` 又使用 `<include ignore_missing="yes">/app/etc/fonts/conf.d/</include>` 用于加载自定义配置，这样后续需要增加其它修改时只需要向 `/app/etc/fonts/conf.d/` 添加新配置即可。

不太确定 `/app/etc/fonts/local.conf` 中包含子目录时相对路径起点是哪，因此使用绝对路径。

该 PR 经过测试修正了 Noto CJK 在中文环境下错误使用 JP 字形的问题。

------

ps. 灵感来自

https://github.com/flathub/org.gnome.OCRFeeder/blob/7c2c53a930dfd80c9dfb7f1cb1d940cef1d4a66c/fonts.conf#L3