### PR TITLE
Update runtime 24.08 & disable screenshot feature

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -1,9 +1,9 @@
 app-id: com.qq.QQ
-runtime: org.gnome.Platform
-runtime-version: '46'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 command: qq
 separate-locales: false
 
@@ -14,7 +14,6 @@ finish-args:
   - --socket=pulseaudio
   - --device=all
   - --filesystem=xdg-download
-  - --talk-name=org.gnome.Shell.Screencast
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.login1
@@ -30,19 +29,6 @@ cleanup:
   - '*.la'
 
 modules:
-  # electron baseapp 23.08 libnotify caused crash, use 22.08 libnotify
-  - name: libnotify
-    buildsystem: meson
-    config-opts:
-      - -Dtests=false
-      - -Dintrospection=disabled
-      - -Dgtk_doc=false
-      - -Ddocbook_docs=disabled
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.8.tar.xz
-        sha256: 69209e0b663776a00c7b6c0e560302a8dbf66b2551d55616304f240bba66e18c
-
   # runtime cups is built aginst openssl
   # need cups with gnutls for qq to load gnutls func
   - name: cups

--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -29,6 +29,19 @@ cleanup:
   - '*.la'
 
 modules:
+
+  - name: kerberos
+    subdir: src
+    sources:
+      - type: archive
+        url: https://kerberos.org/dist/krb5/1.21/krb5-1.21.3.tar.gz
+        sha256: b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35
+        x-checker-data:
+            type: html
+            url: "https://kerberos.org/dist/"
+            version-pattern: "Kerberos V5 Release ([\\d\\.]+) - current release"
+            url-template: "https://kerberos.org/dist/krb5/$major.$minor/krb5-$version.tar.gz"
+
   # runtime cups is built aginst openssl
   # need cups with gnutls for qq to load gnutls func
   - name: cups

--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -18,7 +18,6 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.login1
   - --filesystem=xdg-run/pipewire-0
-  - --filesystem=/tmp
   # required to fix cursor scaling on wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 

--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -14,7 +14,6 @@ finish-args:
   - --socket=pulseaudio
   - --device=all
   - --filesystem=xdg-download
-  - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.login1
   - --filesystem=xdg-run/pipewire-0


### PR DESCRIPTION
考虑到截图功能已经不被支持，使用 gnome runtime 已经没有必要，可以 revert #19 
cc @chenzhiwei  @zhuwjin 