### PR TITLE
update runtime to freedesktop

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -1,27 +1,40 @@
 app-id: com.qq.QQ
-runtime: org.gnome.Platform
-runtime-version: '46'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 command: qq
 separate-locales: false
 
 finish-args:
+  - --device=all
+
   - --share=ipc
   - --share=network
+
   - --socket=x11
   - --socket=pulseaudio
-  - --device=all
+
+  # Filesystems
   - --filesystem=xdg-download
-  - --talk-name=org.gnome.Shell.Screencast
-  - --talk-name=org.freedesktop.Notifications
-  - --talk-name=org.kde.StatusNotifierWatcher
-  - --system-talk-name=org.freedesktop.login1
   - --filesystem=xdg-run/pipewire-0
   - --filesystem=/tmp
+
   # required to fix cursor scaling on wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+
+  # D-Bus Access
+  - --talk-name=org.freedesktop.FileManager1
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --talk-name=org.gnome.Shell.Screencast
+  - --talk-name=org.kde.KWin.ScreenShot2
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+  # System D-Bus Access
+  - --system-talk-name=org.freedesktop.UPower
+  - --system-talk-name=org.freedesktop.login1
 
 cleanup:
   - /include
@@ -66,6 +79,13 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
+
+  - name: kerberos
+    subdir: src
+    sources:
+      - type: archive
+        url: https://kerberos.org/dist/krb5/1.21/krb5-1.21.tar.gz
+        sha256: 69f8aaff85484832df67a4bbacd99b9259bd95aab8c651fbbe65cdc9620ea93b
 
   - name: librename
     buildsystem: simple


### PR DESCRIPTION
fixes https://github.com/flathub/com.qq.QQ/issues/115

测试方式：

安装PR中QQ后，运行`flatpak run --branch=test com.qq.QQ`

目前已知问题：
1. 截图无法使用