### PR TITLE
Remove unnecessary filesystem permission

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -19,7 +19,6 @@ finish-args:
 
   # Filesystems
   - --filesystem=xdg-download
-  - --filesystem=xdg-run/pipewire-0
 
   # required to fix cursor scaling on wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
`xdg-run/pipewire-0` filesystem permission is unnecessary.