### PR TITLE
Use new styled flags to launch QQ with native wayland support

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -110,7 +110,7 @@ modules:
           - |
             if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
             then
-                FLAGS="--enable-features=UseOzonePlatform --ozone-platform=wayland --enable-wayland-ime"
+              FLAGS="--ozone-platform-hint=auto --enable-wayland-ime"
             fi
           - exec zypak-wrapper /app/extra/QQ/qq $FLAGS "$@"
         dest-filename: qq.sh


### PR DESCRIPTION
See https://wiki.archlinux.org/title/Wayland#Command_line_flags for more info.

There should contain at most one `--enable-features` or `--disable-features` flag: https://wiki.archlinux.org/title/Chromium#Hardware_video_acceleration

If user defines their own `--enable-features` and we use `--enable-features` too, there needs modifying launch script to merge them manually.

IMHO, implementing a mechanism to parse arguments and merge them should be the ultimate solution, but that seems to be too complicated for such a tiny wrapper.