### PR TITLE
Remove unnecessary system D-Bus access

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -28,9 +28,6 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.kde.StatusNotifierWatcher
 
-  # System D-Bus Access
-  - --system-talk-name=org.freedesktop.login1
-
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
This pull request removes `org.freedesktop.login1` system D-Bus access.