### PR TITLE
Update QQ package to 3.2.18_250616 and fix x-checker-data patterns

### DIFF
--- a/com.qq.QQ.metainfo.xml
+++ b/com.qq.QQ.metainfo.xml
@@ -29,8 +29,11 @@
     <category>Network</category>
   </categories>
   <releases>
-    <release version="3.2.17_250521" date="2025-05-21">
+    <release version="3.2.18_250616" date="2025-06-16">
       <description></description>
+    </release>
+    <release version="3.2.17_250521" date="2025-05-21">
+      <description/>
     </release>
     <release version="3.2.17_250519" date="2025-05-19">
       <description/>

--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -134,9 +134,9 @@ modules:
       - type: extra-data
         filename: qq.deb
         only-arches: [x86_64]
-        url: https://dldir1.qq.com/qqfile/qq/QQNT/Linux/QQ_3.2.17_250521_amd64_01.deb
-        sha256: 046e90cfe86ab9ec526b9402c16c7abee71be134b475443a518281ff39242358
-        size: 150185686
+        url: https://dldir1v6.qq.com/qqfile/qq/QQNT/Linux/QQ_3.2.18_250616_amd64_01.deb
+        sha256: eff7353f095c5a88173b6dbd7bb7f58185a4b424fe869c90235fb6d9392fccb4
+        size: 150375574
         x-checker-data:
           type: html
           url: https://im.qq.com/rainbow/linuxQQDownload
@@ -146,9 +146,9 @@ modules:
       - type: extra-data
         filename: qq.deb
         only-arches: [aarch64]
-        url: https://dldir1.qq.com/qqfile/qq/QQNT/Linux/QQ_3.2.17_250521_arm64_01.deb
-        sha256: 3dd67dc87cb2c79e58e89e7d66c8c3b178571f23649352414bd2b48b4bee5ff4
-        size: 165699316
+        url: https://dldir1v6.qq.com/qqfile/qq/QQNT/Linux/QQ_3.2.18_250616_arm64_01.deb
+        sha256: c30642fa1cb2ae69a386593885d2539dfe56911c638adeac994983e233ca6ccd
+        size: 165930144
         x-checker-data:
           type: html
           url: https://im.qq.com/rainbow/linuxQQDownload


### PR DESCRIPTION
This PR updates the QQ package to version 3.2.18_250616, adjusting download links and metadata accordingly. It also fix the x-checker-data patterns in com.qq.QQ.yaml to better match download URLs.