### PR TITLE
Add user defined flags support

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -107,7 +107,7 @@ modules:
             if [[ -f "$XDG_CONFIG_HOME/qq-flags.conf" ]]
             then
               echo "Reading user defined flags from $XDG_CONFIG_HOME/qq-flags.conf..."
-              readarray FLAGS <"$XDG_CONFIG_HOME/qq-flags.conf"
+              readarray -t FLAGS <"$XDG_CONFIG_HOME/qq-flags.conf"
             else
               echo "Adding X11 related flags..."
               FLAGS+=(--ozone-platform=x11)


### PR DESCRIPTION
Added a simple user-defined flags support: user can set flags line by line in `$XDG_CONFIG_HOME/qq-flags.conf` and we will pass them to qq. Most of the time it should be `~/.var/app/com.qq.QQ/config/qq-flags.conf`, but user can bind their own file by setting override like `--filesystem=xdg-config/qq-flags.conf`. Due to the limitation of `readarray`,  each line without newline will be treated as an argument entirely.

Another benifit: as flags are stored in an array instead a string, we do not need to pray there is no unwanted space in flags.