### PR TITLE
Use `-e` conditional expression instead of parsing `ls` output

### DIFF
--- a/com.qq.QQ.yaml
+++ b/com.qq.QQ.yaml
@@ -118,7 +118,7 @@ modules:
             fi
           - echo "Pass \`${FLAGS[*]}\` to main process..."
           - |
-            if [ -z "$(ls -A /tmp/.X11-unix 2>/dev/null)" ] && [ -n "$WAYLAND_DISPLAY" ]; then
+            if [ ! -e "/tmp/.X11-unix" ] && [ -n "$WAYLAND_DISPLAY" ]; then
               echo "X11 socket is not available, using Wayland + Xvfb..."
               exec xvfb-run zypak-wrapper /app/extra/QQ/qq "${FLAGS[@]}" "$@"
             else


### PR DESCRIPTION
Use `[ -e file ]` to avoid relying on `ls` output parsing. This makes the script more robust.

Related comment: https://github.com/flathub/com.qq.QQ/pull/212#issuecomment-3592458245