### PR TITLE
Re-enable external data checker

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "disable-external-data-checker": true
-}


### PR DESCRIPTION
Pull request #270 should prevent the external data checker from creating downgrade PRs.