### PR TITLE
Run external data checker from the repo itself

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,52 @@
+name: Update external data
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.repository_owner == 'flathub'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dnsutils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dnsutils
+
+      # https://github.com/awsl1414/aur-packages/blob/c425fe3e/.github/workflows/update-packages.yml
+      - name: Resolve update domain via Chinese DNS
+        run: |
+          set -euo pipefail
+          CHINA_SUBNET="118.134.175.0/24"
+          CHINA_DNS="119.29.29.29"
+          DOMAIN="cdn-go.cn"
+
+          IP=$(dig @"$CHINA_DNS" "$DOMAIN" +subnet="$CHINA_SUBNET" +short \
+            | grep -E '^[0-9]' | head -1)
+          if [ -z "$IP" ]; then
+            echo "ERROR: Failed to resolve $DOMAIN via Chinese DNS" >&2
+            exit 1
+          fi
+          echo "$IP $DOMAIN" | sudo tee -a /etc/hosts
+          echo "Resolved $DOMAIN -> $IP"
+
+          echo "--- verification ---"
+          getent ahosts "$DOMAIN"
+
+      - name: Run flatpak-external-data-checker
+        uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork --require-important-update com.qq.QQ.yaml

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "disable-external-data-checker": true
+}


### PR DESCRIPTION
Moves update checks out of flathub's hosted bot into a daily GitHub Action (20:00 Beijing time) that pins cdn-go.cn to Chinese CDN IPs via DNSPod before checking for new releases.

💘 Generated with Crush

Assisted-by: Crush:deepseek-v4-flash