### PR TITLE
Fix update checker push authentication by downgrading checkout

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     if: github.repository_owner == 'flathub'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install dnsutils
         run: |


### PR DESCRIPTION
checkout v6 stores git credentials in a file under RUNNER_TEMP via includeIf, which is not mounted into the checker's manual docker run, so pushes fall back to the URL-embedded token and are rejected with "Invalid username or token". checkout v4 keeps the credential in .git/config, which travels with the workspace mount.

💘 Generated with Crush

Assisted-by: Crush:deepseek-v4-flash